### PR TITLE
Add Panoramas to Tour

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -45,7 +45,7 @@ const Api = {
         fileWrapper.append("image", file);
         try
         {
-            const { data } = await axios.post("http://127.0.0.1:5000/uploadImage", fileWrapper, {
+            const { data } = await axios.post("/upload-image", fileWrapper, {
                 headers: {
                   'Content-Type': 'multipart/form-data'
                 }

--- a/src/axios-config.ts
+++ b/src/axios-config.ts
@@ -1,4 +1,3 @@
 import axios from "axios";
 
 axios.defaults.baseURL = "http://127.0.0.1:5000/"; // Currently set to the dev server
-axios.defaults.headers.post["Access-Control-Allow-Origin"] = "*";

--- a/src/pages/TourViewer/TourViewer.jsx
+++ b/src/pages/TourViewer/TourViewer.jsx
@@ -14,7 +14,6 @@ export default function TourViewer() {
   const history = useHistory();
   const [tourGraph, updateTour] = useTour();
   const [showAddPopup, setShowAddPopup] = useState(false);
-  const graph = useMemo(() => compileGraphData(tourGraph), [tourGraph]);
 
   async function addTourLocation(e) {
     let contents = new FormData(e.target);
@@ -44,12 +43,27 @@ export default function TourViewer() {
   };
 
   const graphEvents = {
-    select: function (event) {
+    select(event) {
       let { nodes, edges } = event;
       if (nodes.length)
         history.push(history.location.pathname + "/location/" + nodes[0]);
     },
   };
+
+  const graphData = compileGraphData(tourGraph);
+  const graphKey = generateGraphKey(graphData);
+
+  const graph = useMemo(
+    () => (
+      <Graph
+        graph={graphData}
+        key={graphKey}
+        options={options}
+        events={graphEvents}
+      />
+    ),
+    [graphKey]
+  );
 
   return (
     <article className="TourViewer">
@@ -58,22 +72,32 @@ export default function TourViewer() {
           <PlusCircle />
         </button>
       </NavBar>
-      <Graph graph={graph} options={options} events={graphEvents} />
+      {graph}
       <AnimatePresence>
         {showAddPopup && (
           <PopupForm
             onSubmit={addTourLocation}
             onClose={() => setShowAddPopup(false)}
           >
-            <h2>New Panorama</h2>
-            <label>
-              <p>Location Name:</p>
-              <input type="text" name="title" required />
-            </label>
-            <label>
-              <p>Panorama:</p>
-              <input type="file" name="panorama" accept="image/*" required />
-            </label>
+            <h2 className="popup-title">New Panorama</h2>
+            <label htmlFor="title">Location Name:</label>
+
+            <input
+              className="text-field"
+              type="text"
+              name="title"
+              id="title"
+              required
+            />
+
+            <label htmlFor="panorama-file">Panorama:</label>
+            <input
+              type="file"
+              name="panorama"
+              id="panorama-file"
+              accept="image/*"
+              required
+            />
             <input type="submit" value="Add" />
           </PopupForm>
         )}
@@ -102,4 +126,16 @@ function compileGraphData(tourGraph) {
   });
 
   return { nodes, edges };
+}
+
+/**
+ * Graph component key generator since react-graph-vis doesn't work in strict mode :(
+ * @param {*} graphData
+ * @returns A key to determine if the graph changed
+ */
+function generateGraphKey(graphData) {
+  return (
+    graphData.nodes.map((node) => node.id + node.label + node.title).join("") +
+    graphData.edges.map((edge) => edge.to + edge.from).join("")
+  );
 }

--- a/src/pages/TourViewer/TourViewer.jsx
+++ b/src/pages/TourViewer/TourViewer.jsx
@@ -17,6 +17,7 @@ export default function TourViewer() {
 
   async function addTourLocation(e) {
     let contents = new FormData(e.target);
+    setShowAddPopup(false);
     // Add panorama image to the cloud
     const panorama = contents.get("panorama");
     let assetLink = await Api.addImage(panorama);

--- a/src/pages/TourViewer/TourViewer.scss
+++ b/src/pages/TourViewer/TourViewer.scss
@@ -1,4 +1,23 @@
 .TourViewer {
   position: relative;
   height: 100%;
+
+  label {
+    display: block;
+    margin-top: 10px;
+  }
+
+  .text-field {
+    font-family: inherit;
+    padding: 8px 5px;
+    border: 1px solid rgb(165, 165, 165);
+  }
+
+  .popup-title {
+    margin-bottom: 30px;
+  }
+
+  #panorama-file {
+    margin-top: 5px;
+  }
 }


### PR DESCRIPTION
Fixes #1.
## Changes:
- Put in plus button on TourViewer menu bar to add panoramas
- Fixed #10 by generating our own key for the `<Graph/>` component. The internal uid doesn't conform with React Strict Mode.

## Testing:
- Start up frontend and backend servers
- Navigate into the "Cal Poly Tour"
- On the `TourViewer` page, press the plus button in the top right.
- Add a title and a panorama and click "Add"
- Verify that new panorama node is added to the screen
- Click on new panorama node
- Verify that image shows up on the `LocationViewer` screen

**Note:** Refreshing the page before saving on the location viewer will cause an error. This will likely be fixed with #4.
